### PR TITLE
Support non-ARC clients

### DIFF
--- a/FsprgEmbeddedStore/FsprgEmbeddedStoreController.h
+++ b/FsprgEmbeddedStore/FsprgEmbeddedStoreController.h
@@ -16,7 +16,13 @@
  */
 @interface FsprgEmbeddedStoreController : NSObject <NSURLSessionDelegate,NSURLSessionTaskDelegate,NSURLSessionDataDelegate>{
     WebView* webView;
+
+#if !__has_feature(objc_arc)
+    id <FsprgEmbeddedStoreDelegate> delegate;
+#else
     __weak id <FsprgEmbeddedStoreDelegate> delegate;
+#endif
+
     NSString *storeHost;
     NSMutableDictionary *hostCertificates;
     NSMapTable *connectionsToRequests;

--- a/FsprgEmbeddedStore/FsprgEmbeddedStoreController.m
+++ b/FsprgEmbeddedStore/FsprgEmbeddedStoreController.m
@@ -107,6 +107,11 @@
 {
 	// Keep a weak reference to delegates to prevent circular references
 	// See https://developer.apple.com/library/mac/documentation/Cocoa/Conceptual/MemoryMgmt/Articles/mmObjectOwnership.html#//apple_ref/doc/uid/20000043-1044135
+
+#if !__has_feature(objc_arc)
+    [delegate release];
+#endif
+
 	delegate = aDelegate;
 }
 


### PR DESCRIPTION
Since NNW is not yet ARC, you cannot use the `__weak` keyword.  These changes use ARC if enabled and manual reference counting if not.
